### PR TITLE
chore(package): bump tslint-rules version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/driftyco/tslint-ionic-rules#readme",
   "dependencies": {
-    "tslint-eslint-rules": "^1.3.0"
+    "tslint-eslint-rules": "4.1.1"
   },
   "devDependencies": {
-    "typescript": "^1.8.10"
+    "typescript": "2.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "tslint-eslint-rules": "4.1.1"
   },
   "devDependencies": {
-    "typescript": "2.3.3"
+    "typescript": "2.3.4"
   }
 }


### PR DESCRIPTION
To add new rules the dependency should be updated.
I will create a second PR with some rule improvements (in my eyes).

And there are many lint fixes since 1.8.x

I also updated TS to 2.3.3 to match the other ionic packages

Could be merged together with: https://github.com/ionic-team/tslint-ionic-rules/pull/6