### PR TITLE
Upgrade rules to match the new TSLint v5 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/driftyco/tslint-ionic-rules#readme",
   "dependencies": {
-    "tslint-eslint-rules": "^1.3.0"
+    "tslint-eslint-rules": "^4.1.1"
   },
   "devDependencies": {
-    "typescript": "^1.8.10"
+    "typescript": "^2.3.4"
   }
 }

--- a/tslint.js
+++ b/tslint.js
@@ -1,74 +1,50 @@
 var path = require("path");
 
 module.exports = {
-  "extends": "tslint-eslint-rules",
+  "extends": ["tslint-eslint-rules"],
   "rulesDirectory": path.join(path.dirname(require.resolve("tslint-eslint-rules")), "dist/rules"),
   "rules": {
     "class-name": true,
-    "comment-format": [
-      true,
-      "check-space"
-    ],
+    "comment-format": {"options": ["check-space"]},
     "eofline": true,
-    "indent": [
-      true,
-      "spaces"
-    ],
+    "indent": {"options": ["spaces"]},
     "no-debugger": true,
     "no-duplicate-variable": true,
     "no-eval": true,
-    "no-inner-declarations": [
-      true,
-      "functions"
-    ],
+    "no-inner-declarations": {"options": ["functions"]},
     "no-internal-module": true,
     "no-trailing-whitespace": true,
-    "no-unused-variable": [
-      true,
-      {"ignore-pattern": "^_[0-9]*$"}
-    ],
     "no-var-keyword": false,
-    "one-line": [
-      true,
-      "check-catch",
-      "check-else",
-      "check-open-brace",
-      "check-whitespace"
-    ],
-    "quotemark": [
-      true,
-      "single"
-    ],
+    "one-line": {
+      "options": [
+        "check-catch",
+        "check-else",
+        "check-open-brace",
+        "check-whitespace"
+      ]
+    },
+    "quotemark": {"options": ["single"]},
     "radix": true,
-    "semicolon": [
-      true,
-      "always"
-    ],
-    "triple-equals": [
-      true,
-      "allow-null-check"
-    ],
-    "typedef-whitespace": [
-      true,
-      {
+    "semicolon": {"options": ["always"]},
+    "triple-equals": {"options": ["allow-null-check"]},
+    "typedef-whitespace": {
+      "options": {
         "call-signature": "nospace",
         "index-signature": "nospace",
         "parameter": "nospace",
         "property-declaration": "nospace",
         "variable-declaration": "nospace"
       }
-    ],
-    "variable-name": [
-      true,
-      "ban-keywords"
-    ],
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
-    ]
+    },
+    "variable-name": {"options": ["ban-keywords"]},
+    "whitespace": {
+      "options": [
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type"
+      ]
+    }
   }
 }


### PR DESCRIPTION
This is depended on in app-scripts, but it's using the old TSLint API, so I just took the liberty to update.

@danbucholtz 