### PR TITLE
feat: add back no-unused-variable

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -15,6 +15,7 @@ module.exports = {
     "no-internal-module": true,
     "no-trailing-whitespace": true,
     "no-var-keyword": false,
+    "no-unused-variable": true,
     "one-line": {
       "options": [
         "check-catch",


### PR DESCRIPTION
Seems to have been removed here https://github.com/ionic-team/tslint-ionic-rules/commit/9906d31511ecac089a72839ef0697400bc106bcb

This is a "breaking" change because it requires reconfiguration of
tslint. It needs --project to point to the tsconfig.json because it now
requires type information. Without this reconfiguration, you will get
this error:

> Warning: The 'no-unused-variable' rule requires type infomation.

Basically, do this:

`tslint -c tslint.json --project tsconfig.json --type-check`

Instead of this:

`tslint -c tslint.json "src/**/*.ts"`