### PR TITLE
New Lint Rules

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -15,6 +15,7 @@ module.exports = {
     "no-internal-module": true,
     "no-trailing-whitespace": true,
     "no-var-keyword": false,
+    "no-unused-variable": true,
     "one-line": {
       "options": [
         "check-catch",

--- a/tslint.js
+++ b/tslint.js
@@ -1,21 +1,42 @@
-var path = require("path");
+const path = require("path");
 
 module.exports = {
   "extends": ["tslint-eslint-rules"],
   "rulesDirectory": path.join(path.dirname(require.resolve("tslint-eslint-rules")), "dist/rules"),
   "rules": {
+    "align": true,
+    "await-promise": true,
+    "ban-comma-operator": true,
     "class-name": true,
     "comment-format": {"options": ["check-space"]},
+    "encoding": true,
     "eofline": true,
     "indent": {"options": ["spaces"]},
+    "jsdoc-format": [true, "check-multiline-start"],
+    "linebreak-style": [true, "LF"],
+    "new-parens": true,
+    "no-conditional-assignment": true,
     "no-debugger": true,
+    "no-duplicate-super": true,
+    "no-duplicate-switch-case": true,
     "no-duplicate-variable": true,
+    "no-empty": true,
     "no-eval": true,
-    // "no-inner-declarations": {"options": ["functions"]},
+    "no-extra-boolean-cast": true,
+    "no-import-side-effect": true,
+    "no-inferrable-types": true,
     "no-internal-module": true,
+    "no-misused-new": true,
+    "no-non-null-assertion": true,
+    "no-sparse-arrays": true,
+    "no-string-throw": true,
+    "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-var-keyword": false,
+    "no-unnecessary-type-assertion": true,
+    "no-unsafe-finally": true,
     "no-unused-variable": true,
+    "no-var-keyword": true,
+    "no-var-requires": true,
     "one-line": {
       "options": [
         "check-catch",
@@ -30,6 +51,9 @@ module.exports = {
         "named-imports-order": "lowercase-last"
       }
     },
+    "prefer-conditional-expression": true,
+    "prefer-const": true,
+    "prefer-for-of": true,
     "quotemark": {"options": ["single"]},
     "radix": true,
     "semicolon": {"options": ["always"]},
@@ -43,6 +67,7 @@ module.exports = {
         "variable-declaration": "nospace"
       }
     },
+    "use-isnan": true,
     "variable-name": {"options": ["ban-keywords"]},
     "whitespace": {
       "options": [
@@ -52,6 +77,6 @@ module.exports = {
         "check-separator",
         "check-type"
       ]
-    }
+    },
   }
 }


### PR DESCRIPTION
Suggestions for new rules. These are _mostly_ unrelated to code style, but I predict they may require significant refactoring in large code bases.

You can look them up in this list: https://palantir.github.io/tslint/rules
If not listed, it may be an eslint rule from this module, which we depend on: https://www.npmjs.com/package/tslint-eslint-rules#rules-copied-from-the-eslint-website-

Notable things:
* `no-inferrable-types` -> Debatable, but we can let TypeScript infer types wherever possible, which often is more accurate, less verbose, and will require less code edits. 
* `no-var-keyword` -> all uses of `var` disallowed, use `const` or `let`

Additionally, using these new rules requires tslint to have type information, so npm scripts will need updating if they are not updated already. Type information comes from adding the `--project` flag:

`tslint -c tslint.json --project tsconfig.json` (new)
`tslint -c tslint.json "src/**/*.ts"` (old)